### PR TITLE
fixed issue related to the width of sideeelement2

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -86,6 +86,7 @@ nav {
   position: absolute;
   top: 15%;
   right: 3%;
+  min-width: 24px;
 }
 
 .sideelement2.dark-mode {


### PR DESCRIPTION
Adding min-width ensures that .sideelement2 will have at least the specified width, regardless of its content.